### PR TITLE
Ajusta escala a 1.5 y elimina márgenes

### DIFF
--- a/rutinas.html
+++ b/rutinas.html
@@ -2,11 +2,11 @@
 <html lang="es">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=2" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.5" />
   <title>Rutinas · SPA (Vanilla JS)</title>
   <style>
     html{
-      transform:scale(2);
+      transform:scale(1.5);
       transform-origin:top left;
     }
     :root{
@@ -21,8 +21,9 @@
     }
     *{box-sizing:border-box}
     body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,"Helvetica Neue",Arial,"Noto Sans",sans-serif;background:linear-gradient(180deg,#0b1220,#0f172a);color:var(--text)}
-    .container{max-width:960px;margin:24px auto;padding:16px}
-    header{display:flex;flex-wrap:wrap;gap:12px;align-items:center;justify-content:space-between;margin-bottom:16px}
+    p{margin:0}
+    .container{width:100%;margin:0;padding:16px}
+    header{display:flex;flex-wrap:wrap;gap:12px;align-items:center;justify-content:space-between}
     .title{font-size:clamp(20px,3vw,28px);font-weight:700;letter-spacing:.2px}
     .card{background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.08);border-radius:14px;padding:16px}
     .row{display:flex;gap:12px;align-items:center;flex-wrap:wrap}
@@ -33,15 +34,15 @@
     button.accent{background:linear-gradient(180deg,#064e3b,#052e25);border-color:rgba(34,197,94,.5)}
     button.warn{background:linear-gradient(180deg,#3a2b05,#231a03);border-color:rgba(245,158,11,.5)}
     .muted{color:var(--muted)}
-    .section-title{font-weight:700;margin:6px 0 8px 0}
+    .section-title{font-weight:700}
     .big{font-size:22px;font-weight:800}
     .timer{font-variant-numeric:tabular-nums;font-size:26px;font-weight:800}
     .hint{font-size:13px;color:var(--muted)}
     .desc{opacity:.9}
     .next{border-left:3px solid rgba(56,189,248,.5);padding-left:10px}
-    .footer{margin-top:18px;display:flex;gap:10px;flex-wrap:wrap}
+    .footer{display:flex;gap:10px;flex-wrap:wrap}
     .kbd{border:1px solid rgba(255,255,255,.15);border-bottom-width:2px;padding:2px 6px;border-radius:6px;background:#0b1220}
-    .badge{display:inline-block;padding:4px 8px;border-radius:6px;font-size:12px;font-weight:600;margin-right:6px}
+    .badge{display:inline-block;padding:4px 8px;border-radius:6px;font-size:12px;font-weight:600}
     .badge.block{background:rgba(56,189,248,.15);color:var(--accent-2)}
     .badge.step{background:rgba(34,197,94,.15);color:var(--accent)}
   </style>
@@ -68,13 +69,13 @@
     </section>
 
     <!-- Siguiente justo después -->
-    <section class="card" style="margin-top:12px">
+    <section class="card">
       <div class="section-title">Siguiente</div>
       <div id="siguiente"></div>
     </section>
 
     <!-- Resumen al final -->
-    <section class="card" style="margin-top:12px">
+    <section class="card">
       <div class="section-title">Resumen</div>
       <div id="resumenDetalle"></div>
     </section>
@@ -286,12 +287,12 @@ function nextPointer(){
 function renderResumen(){
   const r = currentRutina();
   let html = `<div><span class="badge">Rutina</span> <span class="big">${r.name}</span></div>`;
-  html += `<div class="muted" style="margin:6px 0 10px 0">${r.description}</div>`;
+  html += `<div class="muted" style="padding:6px 0 10px 0">${r.description}</div>`;
   html += r.blocks.map((b,i)=>`
-    <div style="margin:8px 0">
+    <div style="padding:8px 0">
       <div><span class="badge block">Bloque ${i+1}</span> <strong>${b.name}</strong></div>
       <div class="hint">${b.description||''}</div>
-      <ol style="margin:6px 0 0 18px">
+      <ol style="padding:6px 0 0 18px;margin:0">
         ${b.steps.map(s=>`<li class="hint">${s.name}</li>`).join('')}
       </ol>
     </div>`).join('');
@@ -315,8 +316,8 @@ function renderEstado(){
     const step = currentStep();
     html += `<div><span class="badge block">Bloque</span> <span class="big">${b.name}</span></div>`;
     html += `<div class="desc">${b.description||''}</div>`;
-    html += `<div class="muted" style="margin-top:12px">Pulsa <strong>Estoy listo</strong> para empezar:</div>`;
-    html += `<div style="margin-top:8px"><span class="badge step">Paso ${state.stepIndex+1}</span> <strong>${step.name}</strong></div>`;
+    html += `<div class="muted" style="padding-top:12px">Pulsa <strong>Estoy listo</strong> para empezar:</div>`;
+    html += `<div style="padding-top:8px"><span class="badge step">Paso ${state.stepIndex+1}</span> <strong>${step.name}</strong></div>`;
     $listo.style.display = 'inline-block';
     $hecho.style.display = 'none';
   } else if (state.resting){


### PR DESCRIPTION
## Resumen
- Reduce la escala global de la interfaz del doble a 1.5x.
- Elimina márgenes externos e internos para que el contenido aproveche el 100% del ancho disponible.
- Sustituye márgenes en renderizados dinámicos por padding para conservar la separación sin desbordamientos.

## Testing
- `npm test` *(falla: no existe package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d3435be48326907599bcccd62d0b