### PR TITLE
Ajusta escala sin desbordar y reubica controles

### DIFF
--- a/rutinas.html
+++ b/rutinas.html
@@ -2,12 +2,13 @@
 <html lang="es">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.5" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Rutinas · SPA (Vanilla JS)</title>
   <style>
     html{
       transform:scale(1.5);
       transform-origin:top left;
+      width:calc(100%/1.5);
     }
     :root{
       --bg:#0f172a;/* slate-900 */
@@ -23,7 +24,7 @@
     body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,"Helvetica Neue",Arial,"Noto Sans",sans-serif;background:linear-gradient(180deg,#0b1220,#0f172a);color:var(--text)}
     p{margin:0}
     .container{width:100%;margin:0;padding:16px}
-    header{display:flex;flex-wrap:wrap;gap:12px;align-items:center;justify-content:space-between}
+    header{display:flex;flex-direction:column;gap:12px;align-items:flex-start}
     .title{font-size:clamp(20px,3vw,28px);font-weight:700;letter-spacing:.2px}
     .card{background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.08);border-radius:14px;padding:16px}
     .row{display:flex;gap:12px;align-items:center;flex-wrap:wrap}


### PR DESCRIPTION
## Summary
- Evita el desbordamiento horizontal al escalar al 150% ajustando el ancho del elemento raíz y restableciendo el `viewport`
- Coloca el selector de rutina y los botones de control bajo el título para reducir el ancho del encabezado

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d64203848326b2826bd67147db28